### PR TITLE
Add github release link from root-dev page

### DIFF
--- a/app/scripts/components/root-development/index.tsx
+++ b/app/scripts/components/root-development/index.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Button } from '@devseed-ui/button';
-import { CollecticonSpeechBalloon, CollecticonBrandGithub } from '@devseed-ui/collecticons';
+import {
+  CollecticonSpeechBalloon,
+  CollecticonBrandGithub
+} from '@devseed-ui/collecticons';
 
 import { LayoutProps } from '$components/common/layout-root';
 import { PageMainContent } from '$styles/page';
@@ -55,13 +58,13 @@ function RootDevelopment() {
             <CollecticonSpeechBalloon /> Feedback
           </Button>
           <Button
-          size='large'
-          fitting='relaxed'
-          forwardedAs='a'
-          href='https://github.com/NASA-IMPACT/delta-config/releases'
-          variation='primary-fill'
+            size='large'
+            fitting='relaxed'
+            forwardedAs='a'
+            href='https://github.com/NASA-IMPACT/delta-config/releases'
+            variation='primary-fill'
           >
-          <CollecticonBrandGithub /> Releases
+            <CollecticonBrandGithub /> Releases
           </Button>
         </ContributeCta>
       </FoldProse>

--- a/app/scripts/components/root-development/index.tsx
+++ b/app/scripts/components/root-development/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Button } from '@devseed-ui/button';
-import { CollecticonSpeechBalloon } from '@devseed-ui/collecticons';
+import { CollecticonSpeechBalloon, CollecticonBrandGithub } from '@devseed-ui/collecticons';
 
 import { LayoutProps } from '$components/common/layout-root';
 import { PageMainContent } from '$styles/page';
@@ -53,6 +53,15 @@ function RootDevelopment() {
             }}
           >
             <CollecticonSpeechBalloon /> Feedback
+          </Button>
+          <Button
+          size='large'
+          fitting='relaxed'
+          forwardedAs='a'
+          href='https://github.com/NASA-IMPACT/delta-config/releases'
+          variation='primary-fill'
+          >
+          <CollecticonBrandGithub /> Releases
           </Button>
         </ContributeCta>
       </FoldProse>


### PR DESCRIPTION
- We want to make release note public, and I think GitHub's releases page will serve the purpose well.
-Our release note has both changes for contents (which lives in delta-config) and UI (which lives in delta-ui). I think we just need to pick one place to have release notes? I picked delta-config since there are more contributors there. 