### PR TITLE
Add aspect ratio to chart wrapper

### DIFF
--- a/app/scripts/components/common/blocks/lazy-components.js
+++ b/app/scripts/components/common/blocks/lazy-components.js
@@ -18,7 +18,7 @@ import { LoadingSkeleton } from '$components/common/loading-skeleton';
 export function LazyChart(props) {
   return (
     <LazyLoad
-      placeholder={<LoadingSkeleton height={chartMaxHeight + 'px'} />}
+      placeholder={<LoadingSkeleton height={`${chartMaxHeight}px`} />}
       offset={50}
       once
     >

--- a/app/scripts/components/common/blocks/lazy-components.js
+++ b/app/scripts/components/common/blocks/lazy-components.js
@@ -2,7 +2,7 @@ import React from 'react';
 import LazyLoad from 'react-lazyload';
 
 import Chart from '$components/common/chart/block';
-import { chartHeight } from '$components/common/chart/constant';
+import { chartMaxHeight } from '$components/common/chart/constant';
 
 import CompareImage from '$components/common/blocks/images/compare';
 
@@ -18,7 +18,7 @@ import { LoadingSkeleton } from '$components/common/loading-skeleton';
 export function LazyChart(props) {
   return (
     <LazyLoad
-      placeholder={<LoadingSkeleton height={chartHeight} />}
+      placeholder={<LoadingSkeleton height={chartMaxHeight + 'px'} />}
       offset={50}
       once
     >

--- a/app/scripts/components/common/chart/constant.js
+++ b/app/scripts/components/common/chart/constant.js
@@ -1,4 +1,5 @@
-export const chartHeight = '32rem';
+export const chartMaxHeight = 500;
+export const chartAspectRatio = 1.77; // 16:9
 export const defaultMargin = {
   top: 20,
   right: 30,

--- a/app/scripts/components/common/chart/constant.js
+++ b/app/scripts/components/common/chart/constant.js
@@ -1,3 +1,4 @@
+export const chartMinHeight = 200;
 export const chartMaxHeight = 500;
 export const chartAspectRatio = 1.77; // 16:9
 export const defaultMargin = {

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -21,6 +21,7 @@ import AltTitle from './alt-title';
 import { LegendComponent, ReferenceLegendComponent } from './legend';
 import { getColors, dateFormatter, convertToTime } from './utils';
 import {
+  chartMinHeight,
   chartMaxHeight,
   chartAspectRatio,
   defaultMargin,
@@ -34,6 +35,7 @@ const LineChartWithFont = styled(LineChart)`
 
 const ChartWrapper = styled.div`
   width: 100%;
+  grid-column: 1/-1;
 `;
 
 export interface CommonLineChartProps {
@@ -99,7 +101,7 @@ export default function RLineChart (props: RLineChartProps) {
 
   return (
     <ChartWrapper>
-      <ResponsiveContainer aspect={chartAspectRatio} debounce={500} maxHeight={chartMaxHeight}>
+      <ResponsiveContainer aspect={chartAspectRatio} debounce={500} minHeight={chartMinHeight} maxHeight={chartMaxHeight}>
         <LineChartWithFont data={chartData} margin={chartMargin}>
           <AltTitle title={altTitle} desc={altDesc} />
           <CartesianGrid stroke='#efefef' vertical={false} />

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -21,7 +21,8 @@ import AltTitle from './alt-title';
 import { LegendComponent, ReferenceLegendComponent } from './legend';
 import { getColors, dateFormatter, convertToTime } from './utils';
 import {
-  chartHeight,
+  chartMaxHeight,
+  chartAspectRatio,
   defaultMargin,
   highlightColor,
   legendWidth
@@ -33,7 +34,6 @@ const LineChartWithFont = styled(LineChart)`
 
 const ChartWrapper = styled.div`
   width: 100%;
-  height: ${chartHeight};
 `;
 
 export interface CommonLineChartProps {
@@ -99,7 +99,7 @@ export default function RLineChart (props: RLineChartProps) {
 
   return (
     <ChartWrapper>
-      <ResponsiveContainer debounce={500}>
+      <ResponsiveContainer aspect={chartAspectRatio} debounce={500} maxHeight={chartMaxHeight}>
         <LineChartWithFont data={chartData} margin={chartMargin}>
           <AltTitle title={altTitle} desc={altDesc} />
           <CartesianGrid stroke='#efefef' vertical={false} />

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -101,7 +101,12 @@ export default function RLineChart (props: RLineChartProps) {
 
   return (
     <ChartWrapper>
-      <ResponsiveContainer aspect={chartAspectRatio} debounce={500} minHeight={chartMinHeight} maxHeight={chartMaxHeight}>
+      <ResponsiveContainer
+        aspect={chartAspectRatio}
+        debounce={500}
+        minHeight={chartMinHeight}
+        maxHeight={chartMaxHeight}
+      >
         <LineChartWithFont data={chartData} margin={chartMargin}>
           <AltTitle title={altTitle} desc={altDesc} />
           <CartesianGrid stroke='#efefef' vertical={false} />

--- a/app/scripts/components/sandbox/analysis-chart/index.js
+++ b/app/scripts/components/sandbox/analysis-chart/index.js
@@ -4,11 +4,12 @@ import Chart from '$components/common/chart/block';
 import { Fold, FoldHeader, FoldTitle } from '$components/common/fold';
 import Constrainer from '$styles/constrainer';
 import { PageMainContent } from '$styles/page';
+import Hug from '$styles/hug';
 
 const Wrapper = styled.div`
   position: relative;
   grid-column: 1 / -1;
-  min-height: 400px;
+  min-height: 600px;
 `;
 
 function Rechart() {
@@ -18,34 +19,51 @@ function Rechart() {
         <Wrapper>
           <Fold>
             <FoldHeader>
-              <FoldTitle>Chart for MDX</FoldTitle>
+              <FoldTitle>Chart on analysis page</FoldTitle>
             </FoldHeader>
           </Fold>
-          <Chart
-            dataPath={
-              new URL('../../sandbox/mdx-chart/aq.csv', import.meta.url).href
-            }
-            xKey='Year'
-            idKey='Data Type'
-            dateFormat='%Y'
-            yKey='United States Change from 2005'
-            altTitle='no2 and so2'
-            altDesc='no2 and so2 has decreased'
-            xAxisLabel='x axis label'
-            yAxisLabel='y axis label'
-          />
-          <Chart
-            dataPath='/public/example.csv'
-            dateFormat='%m/%d/%Y'
-            idKey='County'
-            xKey='Test Date'
-            yKey='New Positives'
-            altTitle='covid case in Kings county'
-            altDesc='peak in omicron'
-            highlightStart='03/10/2020'
-            highlightEnd='05/01/2020'
-            highlightLabel='Omicron'
-          />
+          <Hug>
+            <Hug
+              grid={{
+                smallUp: ['full-start', 'full-end'],
+                largeUp: ['content-start', 'content-7']
+              }}
+            >
+              <Chart
+                dataPath={
+                  new URL('../../sandbox/mdx-chart/aq.csv', import.meta.url)
+                    .href
+                }
+                xKey='Year'
+                idKey='Data Type'
+                dateFormat='%Y'
+                yKey='United States Change from 2005'
+                altTitle='no2 and so2'
+                altDesc='no2 and so2 has decreased'
+                xAxisLabel='x axis label'
+                yAxisLabel='y axis label'
+              />
+            </Hug>
+            <Hug
+              grid={{
+                smallUp: ['full-start', 'full-end'],
+                largeUp: ['content-7', 'content-end']
+              }}
+            >
+              <Chart
+                dataPath='/public/example.csv'
+                dateFormat='%m/%d/%Y'
+                idKey='County'
+                xKey='Test Date'
+                yKey='New Positives'
+                altTitle='covid case in Kings county'
+                altDesc='peak in omicron'
+                highlightStart='03/10/2020'
+                highlightEnd='05/01/2020'
+                highlightLabel='Omicron'
+              />
+            </Hug>
+          </Hug>
         </Wrapper>
       </Constrainer>
     </PageMainContent>

--- a/app/scripts/components/sandbox/index.js
+++ b/app/scripts/components/sandbox/index.js
@@ -18,6 +18,7 @@ import SandboxMDXScrolly from './mdx-scrollytelling';
 import SandboxAOI from './aoi';
 import SandboxOverride from './override';
 import SandboxChart from './mdx-chart';
+import SandboxAnalysisChart from './analysis-chart';
 
 const pages = [
   {
@@ -54,6 +55,11 @@ const pages = [
     id: 'mdx-chart',
     name: 'Chart',
     component: SandboxChart
+  },
+  {
+    id: 'analysis-chart',
+    name: 'Analysis Page Chart',
+    component: SandboxAnalysisChart
   },
   {
     id: 'cards',


### PR DESCRIPTION
Make chart height to be relative to the width.
I also made a separate page for charts on analysis page in sandbox : https://deploy-preview-242--veda-ui.netlify.app/sandbox/analysis-chart
Follow-up of https://github.com/NASA-IMPACT/delta-ui/pull/239 

