### PR TITLE
Lazy load MdxContent to improve bundle splitting

### DIFF
--- a/app/scripts/components/about/index.js
+++ b/app/scripts/components/about/index.js
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
 import { resourceNotFound } from '$components/uhoh';
 import { LayoutProps } from '$components/common/layout-root';
 import { PageMainContent } from '$styles/page';
 import PageHero from '$components/common/page-hero';
-import MdxContent from '$components/common/mdx-content';
+
+const MdxContent = lazy(() => import('$components/common/mdx-content'));
 
 import { useThematicArea } from '$utils/thematics';
 

--- a/app/scripts/components/common/mdx-content.js
+++ b/app/scripts/components/common/mdx-content.js
@@ -10,7 +10,6 @@ import ContentBlockFigure from '$components/common/blocks/figure';
 import { ContentBlockProse } from '$styles/content-block';
 import Image, { Caption } from '$components/common/blocks/images';
 import { Chapter } from '$components/common/blocks/scrollytelling/chapter';
-
 import {
   LazyChart,
   LazyCompareImage,

--- a/app/scripts/components/common/page-overrides.tsx
+++ b/app/scripts/components/common/page-overrides.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { MDXProvider } from '@mdx-js/react';
 import { getOverride, PageOverrides } from 'delta/thematics';
 
 import { useMdxPageLoader } from '$utils/thematics';
 import { S_SUCCEEDED } from '$utils/status';
-import MdxContent from './mdx-content';
+
+const MdxContent = lazy(() => import('./mdx-content'));
 
 interface ComponentOverrideProps {
   [key: string]: any;

--- a/app/scripts/components/datasets/s-overview/index.js
+++ b/app/scripts/components/datasets/s-overview/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { lazy } from 'react';
 import { Button } from '@devseed-ui/button';
 import { Link } from 'react-router-dom';
 
@@ -7,11 +7,12 @@ import { LayoutProps } from '$components/common/layout-root';
 import { PageActions, PageLead, PageMainContent } from '$styles/page';
 import { DatasetsLocalMenu } from '$components/common/page-local-nav';
 import PageHero from '$components/common/page-hero';
-import MdxContent from '$components/common/mdx-content';
 import RelatedContent from '$components/common/related-content';
 
 import { useThematicArea, useThematicAreaDataset } from '$utils/thematics';
 import { datasetExplorePath, thematicDatasetsPath } from '$utils/routes';
+
+const MdxContent = lazy(() => import('$components/common/mdx-content'));
 
 function DatasetsOverview() {
   const thematic = useThematicArea();

--- a/app/scripts/components/discoveries/single/index.js
+++ b/app/scripts/components/discoveries/single/index.js
@@ -1,14 +1,15 @@
-import React from 'react';
+import React, { lazy } from 'react';
 
 import { resourceNotFound } from '$components/uhoh';
 import { LayoutProps } from '$components/common/layout-root';
 import PageHero from '$components/common/page-hero';
 import { PageMainContent } from '$styles/page';
-import MdxContent from '$components/common/mdx-content';
 import RelatedContent from '$components/common/related-content';
 
 import { useThematicArea, useThematicAreaDiscovery } from '$utils/thematics';
 import { thematicDiscoveriesPath } from '$utils/routes';
+
+const MdxContent = lazy(() => import('$components/common/mdx-content'));
 
 function DiscoveriesSingle() {
   const thematic = useThematicArea();

--- a/app/scripts/components/sandbox/mdx-chart/index.js
+++ b/app/scripts/components/sandbox/mdx-chart/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import MdxContent from '$components/common/mdx-content';
+import React, { lazy } from 'react';
 
+const MdxContent = lazy(() => import('$components/common/mdx-content'));
 const pageLoader = () => import('./chart.mdx');
 
 function SandboxMDXPage() {

--- a/app/scripts/components/sandbox/mdx-page/index.js
+++ b/app/scripts/components/sandbox/mdx-page/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import MdxContent from '$components/common/mdx-content';
+import React, { lazy } from 'react';
 
+const MdxContent = lazy(() => import('$components/common/mdx-content'));
 const pageLoader = () => import('./page.mdx');
 
 function SandboxMDXPage() {

--- a/app/scripts/components/sandbox/mdx-scrollytelling/index.js
+++ b/app/scripts/components/sandbox/mdx-scrollytelling/index.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import MdxContent from '$components/common/mdx-content';
+import React, { lazy } from 'react';
 
+const MdxContent = lazy(() => import('$components/common/mdx-content'));
 const pageLoader = () => import('./page.mdx');
 
 function SandboxMDXScrolly() {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1090606/189330689-20c4516d-ed0e-4cd9-af73-dea2a32a87c9.png)

The `root-about` file was including mapbox in its bundle.
This happens because parcel will bundle the module with the first use. The about page allows for overrides using MdxContent which loads the Map block and so mapbox ended up in this bundle.
I added a lazy load for the MdxComponent thus forcing a split.

![image](https://user-images.githubusercontent.com/1090606/189331069-a663b254-3a46-4f54-8790-d4509f841488.png)

Interesting catch @hanbyul-here 