### PR TITLE
Fix time series chart x axis type

### DIFF
--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -58,7 +58,7 @@ interface RLineChartProps extends CommonLineChartProps {
   uniqueKeys: string[];
 }
 
-export default function RLineChart (props: RLineChartProps) {
+export default function RLineChart(props: RLineChartProps) {
   const {
     chartData,
     uniqueKeys,
@@ -112,6 +112,7 @@ export default function RLineChart (props: RLineChartProps) {
           <CartesianGrid stroke='#efefef' vertical={false} />
           <XAxis
             type='number'
+            scale='time'
             domain={['dataMin', 'dataMax']}
             dataKey={xKey}
             axisLine={false}

--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -111,6 +111,8 @@ export default function RLineChart (props: RLineChartProps) {
           <AltTitle title={altTitle} desc={altDesc} />
           <CartesianGrid stroke='#efefef' vertical={false} />
           <XAxis
+            type='number'
+            domain={['dataMin', 'dataMax']}
             dataKey={xKey}
             axisLine={false}
             tickFormatter={(t) => dateFormatter(t, dateFormat)}


### PR DESCRIPTION
Our chart is for timeseries data and Rechart's Xaxis's default value is 'category'. The problem looks obvious when you have time series data with some gaps.(ex. if the data's dates are '2021/9,'2021/10','2021/12', the chart shows the same interval between the dates when the one between '2021/10' and '2021/12' should be twice.) 

- I wonder the need for other types of charts will emerge in the future? especially in Discovery? 🤔 