### PR TITLE
Set parcel-resolver-thematics filepath to a real file - solve mdx module not found

### DIFF
--- a/parcel-resolver-thematics/index.js
+++ b/parcel-resolver-thematics/index.js
@@ -250,10 +250,8 @@ ${moduleCode}`
 
       const resolved = {
         // When resolving the mdx files, parcel looks at the parent file to know
-        // where to resolve them from and this file has to exist. However if we
-        // use a glob for the file path, parcel doesn't complain that the file
-        // doesn't exist.
-        filePath: path.join(__dirname, '/delta.js'),
+        // where to resolve them from and this file has to exist.
+        filePath: path.join(__dirname, '/delta-thematic.out.js'),
         code: moduleCode,
         invalidateOnFileChange: [
           configPath,


### PR DESCRIPTION
I did not do extensive testing but this seems to solve the problem outlined in #259.

I still don't know exactly why, but setting the virtual module filepath to an actual file with actual module content seems to make a difference, even though this is not what a **virtual** module is supposed to do.