### PR TITLE
Fix Eslint configuration

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,15 +1,13 @@
 {
-  "parser": "@typescript-eslint/parser", // Specifies the ESLint parser
+  "parser": "@babel/eslint-parser",
   "plugins": [
     "react",
     "react-hooks",
-    "@typescript-eslint",
     "inclusive-language",
     "jest"
   ],
   "extends": [
     "eslint:recommended",
-    "plugin:@typescript-eslint/recommended",
     "plugin:react/recommended",
     "plugin:prettier/recommended",
     "plugin:jest/recommended"
@@ -90,9 +88,18 @@
   },
   "overrides": [
     {
-      "files": ["*.tsx","*.ts"],
+      "files": ["**/*.ts", "**/*.tsx"],
+      "plugins": [
+        "@typescript-eslint"
+      ],
       "rules": {
-        "prettier/prettier": "off"
+        "prettier/prettier": "off",
+        "no-unused-vars": "off"
+      },
+      "extends": ["eslint:recommended" /*, "plugin:@typescript-eslint/strict"*/],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "project": ["./tsconfig.json"]
       }
     }
   ]

--- a/app/scripts/components/common/blocks/images/index.js
+++ b/app/scripts/components/common/blocks/images/index.js
@@ -28,7 +28,7 @@ Caption.propTypes = {
 
 export default function Image(props) {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { align, caption, attrAuthor, attrUrl, ...propsWithoutAttrs } = props;
+  const { align, caption, attrAuthor, ...propsWithoutAttrs } = props;
   const imageAlign = align ? align : 'center';
   return caption || attrAuthor ? (
     // if it is an inline image with a caption

--- a/app/scripts/components/common/blocks/scrollytelling/index.tsx
+++ b/app/scripts/components/common/blocks/scrollytelling/index.tsx
@@ -13,7 +13,7 @@ import scrollama from 'scrollama';
 import { CSSTransition, SwitchTransition } from 'react-transition-group';
 import { CollecticonCircleXmark } from '@devseed-ui/collecticons';
 import { media } from '@devseed-ui/theme-provider';
-
+import mapboxgl from 'mapbox-gl';
 import {
   getLayerComponent,
   resolveConfigFunctions

--- a/app/scripts/components/common/chart/analysis/index.tsx
+++ b/app/scripts/components/common/chart/analysis/index.tsx
@@ -18,7 +18,7 @@ interface AnalysisChartProps extends CommonLineChartProps {
   dates: string[];
 }
 
-export default function AnalysisChartProps(props: AnalysisChartProps) {
+export default function AnalysisChart(props: AnalysisChartProps) {
   const { timeSeriesData, dates, uniqueKeys, dateFormat, xKey } = props;
 
   const chartRef = useRef(null);

--- a/app/scripts/components/common/mapbox/aoi/mb-aoi-draw.d.ts
+++ b/app/scripts/components/common/mapbox/aoi/mb-aoi-draw.d.ts
@@ -1,4 +1,5 @@
 import { MutableRefObject } from 'react';
+import mapboxgl from 'mapbox-gl';
 import { DefaultTheme, FlattenInterpolation, ThemeProps } from 'styled-components';
 import { AoiChangeListener, AoiState } from '$components/common/aoi/types';
 

--- a/app/scripts/components/common/mapbox/layers/utils.ts
+++ b/app/scripts/components/common/mapbox/layers/utils.ts
@@ -24,6 +24,7 @@ import { MapLayerRasterTimeseries, StacFeature } from './raster-timeseries';
 import { S_FAILED, S_IDLE, S_LOADING, S_SUCCEEDED } from '$utils/status';
 import { HintedError } from '$utils/hinted-error';
 import mapboxgl from 'mapbox-gl';
+import React from 'react';
 
 export const getLayerComponent = (
   isTimeseries: boolean,
@@ -139,10 +140,12 @@ export function resolveConfigFunctions<T>(
   datum: T,
   bag: DatasetDatumFnResolverBag
 ): Res<T>;
+/* eslint-disable-next-line no-redeclare */
 export function resolveConfigFunctions<T extends Array<any>>(
   datum: T,
   bag: DatasetDatumFnResolverBag
 ): Array<Res<T[number]>>;
+/* eslint-disable-next-line no-redeclare */
 export function resolveConfigFunctions(
   datum: any,
   bag: DatasetDatumFnResolverBag

--- a/app/scripts/components/common/mapbox/map.tsx
+++ b/app/scripts/components/common/mapbox/map.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, RefObject, MutableRefObject, ReactNode } from 'react';
+import React, { useEffect, RefObject, MutableRefObject, ReactNode, ReactElement } from 'react';
 import styled, { useTheme } from 'styled-components';
 import mapboxgl from 'mapbox-gl';
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
@@ -40,7 +40,7 @@ interface SimpleMapProps {
   onProjectionChange?: (projection: ProjectionOptions) => void;
 }
 
-export function SimpleMap(props: SimpleMapProps): ReactNode {
+export function SimpleMap(props: SimpleMapProps): ReactElement {
   const {
     mapRef,
     containerRef,

--- a/app/scripts/components/common/mapbox/map.tsx
+++ b/app/scripts/components/common/mapbox/map.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, RefObject, MutableRefObject } from 'react';
+import React, { useEffect, RefObject, MutableRefObject, ReactNode } from 'react';
 import styled, { useTheme } from 'styled-components';
 import mapboxgl from 'mapbox-gl';
 import MapboxGeocoder from '@mapbox/mapbox-gl-geocoder';
@@ -40,7 +40,7 @@ interface SimpleMapProps {
   onProjectionChange?: (projection: ProjectionOptions) => void;
 }
 
-export function SimpleMap(props: SimpleMapProps): JSX.Element {
+export function SimpleMap(props: SimpleMapProps): ReactNode {
   const {
     mapRef,
     containerRef,

--- a/app/scripts/components/common/related-content.tsx
+++ b/app/scripts/components/common/related-content.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
 import {
@@ -129,7 +129,7 @@ interface RelatedContentProps {
 
 export default function RelatedContent(
   props: RelatedContentProps
-): JSX.Element {
+): ReactNode {
   const { related } = props;
   const relatedContents = formatContents(related);
 

--- a/app/scripts/utils/use-effect-previous.ts
+++ b/app/scripts/utils/use-effect-previous.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 
 type EffectPreviousCb<T> = (previous: T, mounted: boolean) => void | (() => void)
 

--- a/app/scripts/utils/use-safe-state.ts
+++ b/app/scripts/utils/use-safe-state.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * React hook to set state. Same behavior as useState but won't set the state if

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "build": "NODE_ENV=production gulp",
     "stage": "NODE_ENV=staging gulp",
     "clean": "gulp clean",
-    "lint": "yarn lint:js && yarn lint:css",
-    "lint:js": "eslint app/scripts/ --ext .js",
+    "lint": "yarn lint:scripts && yarn lint:css",
+    "lint:scripts": "eslint app/scripts/",
     "lint:css": "stylelint 'app/styles/**/**' 'app/scripts/**/*.js'",
     "ts-check": "yarn tsc --noEmit --skipLibCheck",
     "test": "jest"


### PR DESCRIPTION
This is a review of the project's eslint config:
- Renamed the package.json script from `lint:js` to `lint:scripts` and actually check ts files as well 
- Configured eslint so that it uses a distinct parser for js and ts files as it should be on js/ts mixed codebases (explicitly set `@babel/eslint-parser` for JS files, before that it was using `@typescript-eslint/parser` to lint JS files) 
- I did not activate eslint typescript in _strict_ mode, as it generates 180 warnings. I did not realize that when writing <a href="https://github.com/NASA-IMPACT/delta-ui/pull/278#discussion_r999614894">this</a> because running eslint from yarn did not actually check TS files.
  - Ways to tackle this is either we leave it as is for now, or try to do it progressively, or wait to have a relatively low number of open PRs and fix all affected files in one go
- Fixed any errors left in either JS or TS files, keeping `react-hooks/exhaustive-deps` as discussed