### PR TITLE
Use google-polyline to encode AoIs

### DIFF
--- a/app/scripts/components/analysis/results/use-analysis-params.ts
+++ b/app/scripts/components/analysis/results/use-analysis-params.ts
@@ -148,7 +148,7 @@ export function analysisParams2QueryString(
     datasetsLayers: params.datasetsLayers
       ? params.datasetsLayers.map((d) => d.id).join('|')
       : undefined,
-    aoi: params.aoi ? polygonUrlEncode(params.aoi, 4) : undefined
+    aoi: params.aoi ? polygonUrlEncode(params.aoi) : undefined
   });
 
   return urlParams ? `?${urlParams}` : '';

--- a/app/scripts/utils/polygon-url.ts
+++ b/app/scripts/utils/polygon-url.ts
@@ -38,22 +38,13 @@ export function polygonUrlDecode(polygonStr: string) {
  *
  */
 export function polygonUrlEncode(
-  f: Feature<MultiPolygon>,
-  precision = Infinity
+  f: Feature<MultiPolygon>
 ) {
   return f.geometry.coordinates
     .map((polygon) => {
       const points = polygon[0]
         // Remove last coordinate since it is repeated.
-        .slice(0, -1)
-        .map((point) => {
-          let p = point;
-          if (precision !== Infinity) {
-            const m = Math.pow(10, precision);
-            p = point.map((v) => Math.floor(v * m) / m);
-          }
-          return p;
-        });
+        .slice(0, -1);
       return encode(points);
     })
     .join('||');

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "date-fns": "^2.28.0",
     "file-saver": "^2.0.5",
     "geojson-validation": "^1.0.2",
+    "google-polyline": "^1.0.3",
     "history": "^5.1.0",
     "intersection-observer": "^0.12.0",
     "jest-environment-jsdom": "^28.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6311,6 +6311,11 @@ gonzales-pe@^4.3.0:
   dependencies:
     minimist "^1.2.5"
 
+google-polyline@^1.0.3:
+  version "1.0.3"
+  resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/google-polyline/-/google-polyline-1.0.3.tgz#b1fafd8841059f7049d4ba6767c386be979510dc"
+  integrity sha512-36BnqVxmVcR8lTvzO6aeXdICNChAwQLlfMkR1P9IBpTWE8hA6bAbQHCVArwMHB5WIMq9owywtAkjioe3crNq4Q==
+
 got@^10.7.0:
   version "10.7.0"
   resolved "http://ec2-3-82-125-171.compute-1.amazonaws.com:4873/got/-/got-10.7.0.tgz#62889dbcd6cca32cd6a154cc2d0c6895121d091f"


### PR DESCRIPTION
Uses Google [encoded polyline format](https://developers.google.com/maps/documentation/utilities/polylinealgorithm) to store AoIs in the URL. 
Pros: shorter and removes the need to specify coordinate precision.

Example before:
`aoi=-37.8024%2C49.5942%7C-17.1423%2C13.3474%7C61.5155%2C5.496%7C102.0889%2C30.1452%7C111.7967%2C57.4124%7C71.2232%2C62.6241%7C-13.9064%2C63.5257%7C-29.5881%2C60.7354`

Now:
`aoi=~cn%7CG_d%7B%7DBoxayQ~bydGdwtaJiqjxIesuaNusvqArmsuS~quUzvhPgyssA~lfwAvbx%7B%40n~_RfssnA`

(with 8 points)