### PR TITLE
Add multiple links

### DIFF
--- a/app/scripts/components/datasets/s-usage/index.js
+++ b/app/scripts/components/datasets/s-usage/index.js
@@ -45,11 +45,13 @@ function DatasetsUsage() {
       <PageMainContent>
         <PageHero title={`${dataset.data.name} Usage`} />
         <FoldProse>
-          {datasetUsage?.url && datasetUsage?.title ? (
+          {datasetUsage?.length > 0 ? (
             <>
               <p>
-                Check out how to use this dataset in this example notebook:{' '}
-                <a href={datasetUsage.url}>{datasetUsage.title}</a>.
+                Check out how to use this dataset:{' '}
+                {datasetUsage.map((du) => (
+                  <li>{du.description}:{' '}<a href={du.url}>{du.title}</a></li>
+                ))}
               </p>
               <p>
                 For reference, the following STAC collection ID&apos;s are

--- a/app/scripts/components/datasets/s-usage/index.js
+++ b/app/scripts/components/datasets/s-usage/index.js
@@ -17,7 +17,7 @@ function DatasetsUsage() {
 
   if (!thematic || !dataset) throw resourceNotFound();
 
-  const datasetUsage = dataset.data.usage;
+  const datasetUsages = dataset.data.usage;
 
   const layerIdsSet = dataset.data.layers.reduce(
     (acc, layer) => acc.add(layer.stacCol),
@@ -45,14 +45,17 @@ function DatasetsUsage() {
       <PageMainContent>
         <PageHero title={`${dataset.data.name} Usage`} />
         <FoldProse>
-          {datasetUsage?.length > 0 ? (
+          {datasetUsages?.length ? (
             <>
               <p>
                 Check out how to use this dataset:{' '}
                 <ul>
-                {datasetUsage.map((du) => (
-                  <li>{du.description}:{' '}<a href={du.url}>{du.title}</a></li>
-                ))}
+                  {datasetUsages.map((datasetUsage) => (
+                    <li key={datasetUsage.url}>
+                      {datasetUsage.description}:{' '}
+                      <a href={datasetUsage.url}>{datasetUsage.title}</a>
+                    </li>
+                  ))}
                 </ul>
               </p>
               <p>

--- a/app/scripts/components/datasets/s-usage/index.js
+++ b/app/scripts/components/datasets/s-usage/index.js
@@ -49,9 +49,11 @@ function DatasetsUsage() {
             <>
               <p>
                 Check out how to use this dataset:{' '}
+                <ul>
                 {datasetUsage.map((du) => (
                   <li>{du.description}:{' '}<a href={du.url}>{du.title}</a></li>
                 ))}
+                </ul>
               </p>
               <p>
                 For reference, the following STAC collection ID&apos;s are

--- a/app/scripts/components/datasets/s-usage/index.js
+++ b/app/scripts/components/datasets/s-usage/index.js
@@ -47,17 +47,15 @@ function DatasetsUsage() {
         <FoldProse>
           {datasetUsages?.length ? (
             <>
-              <p>
-                Check out how to use this dataset:{' '}
-                <ul>
-                  {datasetUsages.map((datasetUsage) => (
-                    <li key={datasetUsage.url}>
-                      {datasetUsage.description}:{' '}
-                      <a href={datasetUsage.url}>{datasetUsage.title}</a>
-                    </li>
-                  ))}
-                </ul>
-              </p>
+              <p>Check out how to use this dataset:</p>
+              <ul>
+                {datasetUsages.map((datasetUsage) => (
+                  <li key={datasetUsage.url}>
+                    {datasetUsage.label}:{' '}
+                    <a href={datasetUsage.url}>{datasetUsage.title}</a>
+                  </li>
+                ))}
+              </ul>
               <p>
                 For reference, the following STAC collection ID&apos;s are
                 associated with this dataset:

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -8,6 +8,9 @@ usage:
   - url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
     description: Static notebook
     title: 'Time series using STAC API statistics endpoints'
+  - url: 'https://daskhub.veda.smce.nasa.gov/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fnasa-impact%2Fveda-documentation&urlpath=lab%2Ftree%2Fveda-documentation%2Ftimeseries-stac-api.ipynb&branch=main'
+    description: SMCE DaskHub
+    title: 'Time series using STAC API statistics endpoints'
 media:
   src: ::file ./no2--dataset-cover.jpg
   alt: Power plant shooting steam at the sky.

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -6,10 +6,10 @@ featuredOn:
 description: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
 usage:
   - url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
-    description: Static notebook
+    label: Static notebook
     title: 'Time series using STAC API statistics endpoints'
   - url: 'https://daskhub.veda.smce.nasa.gov/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fnasa-impact%2Fveda-documentation&urlpath=lab%2Ftree%2Fveda-documentation%2Ftimeseries-stac-api.ipynb&branch=main'
-    description: SMCE DaskHub
+    label: SMCE DaskHub
     title: 'Time series using STAC API statistics endpoints'
 media:
   src: ::file ./no2--dataset-cover.jpg

--- a/mock/datasets/no2.data.mdx
+++ b/mock/datasets/no2.data.mdx
@@ -5,8 +5,9 @@ featuredOn:
   - covid-19
 description: "Since the outbreak of the novel coronavirus, atmospheric concentrations of nitrogen dioxide have changed by as much as 60% in some regions."
 usage:
-  url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
-  title: 'Time series using STAC API statistics endpoints'
+  - url: 'https://nasa-impact.github.io/veda-documentation/timeseries-stac-api.html'
+    description: Static notebook
+    title: 'Time series using STAC API statistics endpoints'
 media:
   src: ::file ./no2--dataset-cover.jpg
   alt: Power plant shooting steam at the sky.

--- a/parcel-resolver-thematics/index.d.ts
+++ b/parcel-resolver-thematics/index.d.ts
@@ -110,6 +110,11 @@ declare module 'delta/thematics' {
     thematic?: string;
   }
 
+  export interface DatasetUsage {
+    url: string;
+    description: string;
+    title: string;
+  }
   /**
    * Data structure for the Datasets frontmatter.
    */
@@ -119,10 +124,7 @@ declare module 'delta/thematics' {
     name: string;
     thematics: string[];
     description: string;
-    usage?: {
-      url: string;
-      title: string;
-    };
+    usage?: DatasetUsage[];
     media?: Media;
     layers: DatasetLayer[];
     related?: RelatedContentData[];

--- a/parcel-resolver-thematics/index.d.ts
+++ b/parcel-resolver-thematics/index.d.ts
@@ -112,7 +112,7 @@ declare module 'delta/thematics' {
 
   export interface DatasetUsage {
     url: string;
-    description: string;
+    label: string;
     title: string;
   }
   /**


### PR DESCRIPTION
Addresses https://github.com/NASA-IMPACT/delta-ui/issues/293

This is not fancy in any way but curious if this approach is what others were thinking to include multiple ways to open the notebooks

<img width="1615" alt="Screen Shot 2022-11-07 at 3 57 26 PM" src="https://user-images.githubusercontent.com/15016780/200440771-331ebb40-d323-4a5a-b14a-f33aa0b899b9.png">