### PR TITLE
Use position absolute for the header

### DIFF
--- a/app/scripts/components/common/nav-wrapper.js
+++ b/app/scripts/components/common/nav-wrapper.js
@@ -11,16 +11,17 @@ import { HEADER_WRAPPER_ID } from '$utils/use-sliding-sticky-header';
 const NavWrapper = styled.div`
   position: sticky;
   top: 0;
-  z-index: 1000;
+  width: 100%;
+  z-index: 10000;
 
-  transition: transform 0.32s ease-out;
+  transition: top 0.32s ease-out;
   ${({ shouldSlideHeader, headerHeight }) =>
     // Hide the header by translating the nav by the header's height. The
     // translate is in the NavWrapper and not the header because in this way the
     // localNav (also inside the NavWrapper) will stick to the top.
     shouldSlideHeader &&
     css`
-      transform: translate(0, -${headerHeight}px);
+      top: -${headerHeight}px;
     `}
 `;
 


### PR DESCRIPTION
Address the problem outlined in #312.
The fix I implemented relies in using `position: fixed` for the header and compensating its height as padding on the page. I still don't understand why the scroll context is lost.

Looking for some feedback from @ricardoduplos on the approach before merging