### PR TITLE
Analysis presets

### DIFF
--- a/app/scripts/components/analysis/define/constants.ts
+++ b/app/scripts/components/analysis/define/constants.ts
@@ -1,0 +1,22 @@
+import { Feature, Polygon } from 'geojson';
+
+export type RegionPreset = 'world';
+
+export const FeatureByRegionPreset: Record<RegionPreset, Feature<Polygon>> = {
+  world: {
+    type: 'Feature',
+    properties: {},
+    geometry: {
+      coordinates: [
+        [
+          [-180, -89],
+          [180, -89],
+          [180, 89],
+          [-180, 89],
+          [-180, -89]
+        ]
+      ],
+      type: 'Polygon'
+    }
+  }
+};

--- a/app/scripts/components/analysis/define/index.tsx
+++ b/app/scripts/components/analysis/define/index.tsx
@@ -42,7 +42,12 @@ import {
 } from '$components/common/fold';
 import { S_FAILED, S_LOADING, S_SUCCEEDED } from '$utils/status';
 import { useAoiControls } from '$components/common/aoi/use-aoi-controls';
-import { dateToInputFormat, inputFormatToDate } from '$utils/date';
+import {
+  DateRangePreset,
+  dateToInputFormat,
+  getRangeFromPreset,
+  inputFormatToDate
+} from '$utils/date';
 
 const FormBlock = styled.div`
   display: flex;
@@ -125,6 +130,15 @@ export default function Analysis() {
         return;
       }
       setAnalysisParam('end', inputFormatToDate(e.target.value));
+    },
+    [setAnalysisParam]
+  );
+
+  const onDatePresetClick = useCallback(
+    (preset: DateRangePreset) => {
+      const { start, end } = getRangeFromPreset(preset);
+      setAnalysisParam('start', start);
+      setAnalysisParam('end', end);
     },
     [setAnalysisParam]
   );
@@ -253,16 +267,36 @@ export default function Analysis() {
                 <DropTitle>Select a date preset</DropTitle>
                 <DropMenu>
                   <li>
-                    <DropMenuItem href='#'>Preset A</DropMenuItem>
+                    <DropMenuItem
+                      role='button'
+                      onClick={() => onDatePresetClick('thisYear')}
+                    >
+                      This year
+                    </DropMenuItem>
                   </li>
                   <li>
-                    <DropMenuItem href='#'>Preset B</DropMenuItem>
+                    <DropMenuItem
+                      role='button'
+                      onClick={() => onDatePresetClick('last30Days')}
+                    >
+                      Last 30 days
+                    </DropMenuItem>
                   </li>
                   <li>
-                    <DropMenuItem href='#'>Preset C</DropMenuItem>
+                    <DropMenuItem
+                      role='button'
+                      onClick={() => onDatePresetClick('lastYear')}
+                    >
+                      Last year
+                    </DropMenuItem>
                   </li>
                   <li>
-                    <DropMenuItem href='#'>Preset D</DropMenuItem>
+                    <DropMenuItem
+                      role='button'
+                      onClick={() => onDatePresetClick('last10Years')}
+                    >
+                      Last 10 years
+                    </DropMenuItem>
                   </li>
                 </DropMenu>
               </Dropdown>

--- a/app/scripts/components/common/aoi/types.d.ts
+++ b/app/scripts/components/common/aoi/types.d.ts
@@ -34,11 +34,11 @@ export type AoiChangeListener = (
   }
 ) => void;
 
-export type AoiChangeListenerOverload = {
-  (action: 'aoi.draw-click', payload?: never): void;
-  (action: 'aoi.set-feature', payload: { feature: AoiFeature }): void;
-  (action: 'aoi.clear', payload?: never): void;
-  (action: 'aoi.draw-finish', payload: { feature: AoiFeature }): void;
+export interface AoiChangeListenerOverload {
+  (action: 'aoi.draw-click' | 'aoi.clear', payload?: never): void;
+  (
+    action: 'aoi.draw-finish' | 'aoi.set-feature' | 'aoi.update',
+    payload: { feature: AoiFeature }
+  ): void;
   (action: 'aoi.selection', payload: { selected: boolean }): void;
-  (action: 'aoi.update', payload: { feature: AoiFeature }): void;
-};
+}

--- a/app/scripts/utils/date.ts
+++ b/app/scripts/utils/date.ts
@@ -1,4 +1,12 @@
-import { format, isSameMonth, isSameYear, parse } from 'date-fns';
+import {
+  format,
+  isSameMonth,
+  isSameYear,
+  parse,
+  endOfYear,
+  startOfYear,
+  sub
+} from 'date-fns';
 
 /**
  * Create a date which matches the input date offsetting the timezone to match
@@ -131,10 +139,10 @@ export function formatDateRange(start: Date, end: Date) {
 
 /**
  * Converts a native JS date to the format accepted by HTML inputs
- * @param date 
+ * @param date
  * @returns string
  */
- export function dateToInputFormat(date?: Date) {
+export function dateToInputFormat(date?: Date) {
   if (!date) return undefined;
   return format(date, 'yyyy-MM-dd');
 }
@@ -143,4 +151,26 @@ export function inputFormatToDate(inputFormat: string) {
   return parse(inputFormat, 'yyyy-MM-dd', new Date());
 }
 
-
+export type DateRangePreset =
+  | 'thisYear'
+  | 'last30Days'
+  | 'lastYear'
+  | 'last10Years';
+export function getRangeFromPreset(preset: DateRangePreset): {
+  start: Date;
+  end: Date;
+} {
+  const end = preset === 'thisYear' ? endOfYear(new Date()) : new Date();
+  let start = startOfYear(new Date());
+  if (preset === 'last30Days') {
+    start = sub(end, { days: 30 });
+  } else if (preset === 'lastYear') {
+    start = sub(end, { years: 1 });
+  } else if (preset === 'last10Years') {
+    start = sub(end, { years: 10 });
+  }
+  return {
+    start,
+    end
+  };
+}


### PR DESCRIPTION


![Screenshot 2022-11-15 at 12 27 46](https://user-images.githubusercontent.com/1583415/201916071-04683257-93a7-4989-be01-9ad9e5a29725.png)
![Screenshot 2022-11-15 at 13 10 00](https://user-images.githubusercontent.com/1583415/201916546-91a85da5-cb05-4b40-9029-733058c7e0f7.png)

Adds options to automatically select date ranges and regions in the analysis page.
Mostly I wanted to be able to debug the analysis page more quickly, but this should serve as a base for when we decide which presets we want to offer (for now  `'thisYear'   | 'last30Days'  | 'lastYear'   | 'last10Years'` for dates and `'world'` for regions) .

TODO for later:
- decide on presets
- figure out a way to use multipolygons (it will be needed for anything like 'USA' as a region)

