### PR TITLE
Explicitely export to PNG

### DIFF
--- a/app/scripts/components/analysis/results/chart-card.tsx
+++ b/app/scripts/components/analysis/results/chart-card.tsx
@@ -157,7 +157,7 @@ export default function ChartCard(props: ChartCardProps) {
                   <DropMenuItemButton
                     onClick={(e) => onExportClick(e, 'image')}
                   >
-                    Image (JPG)
+                    Image (PNG)
                   </DropMenuItemButton>
                 </li>
                 <li>

--- a/app/scripts/components/common/chart/analysis/index.tsx
+++ b/app/scripts/components/common/chart/analysis/index.tsx
@@ -56,7 +56,7 @@ export default React.forwardRef<AnalysisChartRef, AnalysisChartProps>(
               lineColors: props.colors
             })
           });
-          FileSaver.saveAs(chartImageUrl, `${name}.jpg`);
+          FileSaver.saveAs(chartImageUrl, `${name}.png`);
         }
       }),
       [uniqueKeys, props.colors, altTitle]

--- a/app/scripts/components/common/chart/analysis/utils.ts
+++ b/app/scripts/components/common/chart/analysis/utils.ts
@@ -157,8 +157,8 @@ function drawOnCanvas({
     legendHeight
   );
 
-  const jpg = c.toDataURL('image/jpg');
-  return jpg;
+  const png = c.toDataURL();
+  return png;
 }
 
 function loadImageWithPromise(url: string) {


### PR DESCRIPTION
Related to https://github.com/NASA-IMPACT/delta-ui/issues/336

Turns out, because there was a typo on the MIME type used in `toDataURL` (jpg, not jpeg), the file exported was _already_ a PNG (`toDataURL` defaults to PNG if MIME type is invalid), only with a `.jpg` extension.

This PR makes it explicitly a PNG file. I have opted not to use WebP eventually because:
- it is not supported with `toDataURL` in Safari
- I'm not sure the format is common enough so that people know how to handle it on their desktops.