### PR TITLE
put value as sync method

### DIFF
--- a/app/scripts/components/common/chart/index.tsx
+++ b/app/scripts/components/common/chart/index.tsx
@@ -163,17 +163,7 @@ export default React.forwardRef<ChartWrapperRef, RLineChartProps>(
             data={chartData}
             margin={chartMargin}
             syncId={syncId}
-            syncMethod={(tick, data) => {
-              const index = syncMethodFunction({
-                data,
-                chartData,
-                xKey,
-                dateFormat,
-                startDate: chartData[brushStartIndex][xKey],
-                endDate: chartData[brushStartIndex][xKey],
-              });
-              return index;
-            }}
+            syncMethod='value'
           >
             <AltTitle title={altTitle} desc={altDesc} />
             <CartesianGrid stroke='#efefef' vertical={false} />


### PR DESCRIPTION
While trying to close the issue https://github.com/NASA-IMPACT/delta-ui/issues/326 
I noticed that the brush ranges don't get synced up when the whole brush handle moves. (instead of moving start/end handle) This makes syncing values up across charts (hard to decide which data to be based on to find the index of synced value.) You can see it in action: 
 https://deploy-preview-343--veda-ui.netlify.app/air-quality/analysis/results?start=2022-01-02T00%3A00%3A00.000Z&end=2022-03-17T00%3A00%3A00.000Z&datasetsLayers=no2-monthly-diff%7Cno2-monthly&aoi=xpfbKcbk%7B%40_imlAr%7BrK%7CaqPz%60i%60A~%7B_vA%7Bpi%5D

This PR doesn't solve the problem, but this pr tries to sync up tooltips only when there is a matching value. (so 2022/02 won't sync with 2022 tooltip anymore.) so tooltips at least don't return confusing values.  I think this simplifies many things but would like to ask for feedback from a scientist about it.

