### PR TITLE
Dataset related errors

### DIFF
--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -90,10 +90,8 @@ const DatesWrapper = styled.div`
   }
 `;
 
-const isSelectedDateValid = (dateList, prevDateList, selectedDate) => {
-  const currDates = JSON.stringify(dateList);
-  const prevDates = JSON.stringify(prevDateList);
-  if (dateList && currDates !== prevDates) {
+const isSelectedDateValid = (dateList, selectedDate) => {
+  if (dateList) {
     // Since the available dates changes, check if the currently selected
     // one is valid.
     const validDate = !!dateList.find(
@@ -116,9 +114,7 @@ const getInitialDate = (dateList, initialDatetime) => {
 
   const initialDate = utcString2userTzDate(initialDatetime);
   // Reuse isSelectedDateValid function.
-  return isSelectedDateValid(dateList, undefined, initialDate)
-    ? initialDate
-    : dateList[0];
+  return isSelectedDateValid(dateList, initialDate) ? initialDate : dateList[0];
 };
 
 const useValidSelectedDate = (
@@ -127,14 +123,11 @@ const useValidSelectedDate = (
   initialDatetime,
   setDate
 ) => {
-  useEffectPrevious(
-    ([prevDateList]) => {
-      if (!isSelectedDateValid(dateList, prevDateList, selectedDate)) {
-        setDate(getInitialDate(dateList, initialDatetime));
-      }
-    },
-    [dateList, selectedDate, setDate]
-  );
+  useEffect(() => {
+    if (!isSelectedDateValid(dateList, selectedDate)) {
+      setDate(getInitialDate(dateList, initialDatetime));
+    }
+  }, [dateList, selectedDate, initialDatetime, setDate]);
 };
 
 const useValidSelectedCompareDate = (
@@ -143,18 +136,12 @@ const useValidSelectedCompareDate = (
   initialDatetime,
   setDate
 ) => {
-  useEffectPrevious(
-    ([prevDateList]) => {
-      // A compare date can be null.
-      if (
-        selectedDate &&
-        !isSelectedDateValid(dateList, prevDateList, selectedDate)
-      ) {
-        setDate(getInitialDate(dateList, initialDatetime));
-      }
-    },
-    [dateList, selectedDate, setDate]
-  );
+  useEffect(() => {
+    // A compare date can be null.
+    if (selectedDate && !isSelectedDateValid(dateList, selectedDate)) {
+      setDate(getInitialDate(dateList, initialDatetime));
+    }
+  }, [dateList, selectedDate, initialDatetime, setDate]);
 };
 
 const useDatePickerValue = (

--- a/app/scripts/components/datasets/s-explore/index.tsx
+++ b/app/scripts/components/datasets/s-explore/index.tsx
@@ -363,10 +363,11 @@ function DatasetsExplore() {
         !prevActiveData ||
         !currActiveData ||
         prevActiveData.id === currActiveData.id
-      )
+      ) {
         return;
+      }
 
-      if (currActiveData.projection.id) {
+      if (currActiveData.projection?.id) {
         setMapProjection(currActiveData.projection);
       } else {
         setMapProjection(projectionDefault);

--- a/parcel-resolver-thematics/index.d.ts
+++ b/parcel-resolver-thematics/index.d.ts
@@ -52,10 +52,10 @@ declare module 'delta/thematics' {
     name: string;
     description: string;
     initialDatetime?: 'newest' | 'oldest' | string;
-    projection: ProjectionOptions;
+    projection?: ProjectionOptions;
     type: DatasetLayerType;
     compare: DatasetLayerCompareSTAC | DatasetLayerCompareInternal | null;
-    legend: LayerLegendCategorical | LayerLegendGradient;
+    legend?: LayerLegendCategorical | LayerLegendGradient;
   }
 
   // A normalized compare layer is the result after the compare definition is


### PR DESCRIPTION
Addresses the error found in https://github.com/NASA-IMPACT/delta-config/pull/142 and #342

@hanbyul-here @nerik We have to be very careful with the "Unnecessary optional chain on a non-nullish value" or the "Values always truthy" suggestions of typescript. Some types may not be properly defined (like the data coming from the MDX frontmatter), and accepting those suggestions may lead to the app breaking. When faced with this we should double check the types and update accordingly.

@Catalina-Moller Can you double check the errors are fixed?